### PR TITLE
API keys

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -4,5 +4,6 @@
   "dbName": "autoexam",
   "questionsCollection": "questions",
   "tagsCollection": "tags",
+  "apiKeysCollection": "api_keys",
   "superuserApiKey": "REPLACE_THIS_KEY"
 }

--- a/config-template.json
+++ b/config-template.json
@@ -3,5 +3,6 @@
   "saveDirectory": "storage/activities",
   "dbName": "autoexam",
   "questionsCollection": "questions",
-  "tagsCollection": "tags"
+  "tagsCollection": "tags",
+  "superuserApiKey": "REPLACE_THIS_KEY"
 }

--- a/controllers/api-key-controller.js
+++ b/controllers/api-key-controller.js
@@ -26,7 +26,7 @@ async function createKey(req, res) {
 
 const standardDelete = crudCreator.makeDelete('key');
 async function augmentedDelete(req, res) {
-    if (req.ApiKey === req.params.key) return res.status(409).send(`You can't delete the key you're using.`);
+    if (req.apiKey === req.params.key) return res.status(409).send(`You can't delete the key you're using.`);
     return await standardDelete(req, res);
 }
 

--- a/controllers/api-key-controller.js
+++ b/controllers/api-key-controller.js
@@ -1,0 +1,37 @@
+const MakeCrudFromMongoSchema = require('../utilities/make-crud-from-mongo-schema');
+const { ApiKey } = require('../models');
+
+const crudCreator = MakeCrudFromMongoSchema('API key', ApiKey, 'key');
+
+async function createKey(req, res) {
+    const obj = new ApiKey();
+    obj.key = "";
+
+    const randomChar = () => {
+        // Create [0-9A-Za-z]
+        let ret = Math.floor(Math.random() * 62) + 48;
+        if (ret <= 57) return String.fromCharCode(ret);
+        ret += 7;
+        if (ret <= 90) return String.fromCharCode(ret);
+        ret += 6;
+        if (ret <= 122) return String.fromCharCode(ret);
+        throw new Error(`Shouldn't ever get here...`);
+    }
+    for(let i=0; i<12; i++) {
+        obj.key += randomChar();
+    }
+    await obj.save();
+    res.status(201).send({ key: obj.key });
+}
+
+const standardDelete = crudCreator.makeDelete('key');
+async function augmentedDelete(req, res) {
+    if (req.ApiKey === req.params.key) return res.status(409).send(`You can't delete the key you're using.`);
+    return await standardDelete(req, res);
+}
+
+module.exports = {
+    getKeys: crudCreator.makeList(),
+    createKey: createKey,
+    deleteKey: augmentedDelete
+}

--- a/controllers/api-key-controller.js
+++ b/controllers/api-key-controller.js
@@ -8,7 +8,7 @@ async function createKey(req, res) {
     obj.key = "";
 
     const randomChar = () => {
-        // Create [0-9A-Za-z]
+        // Create a character in [0-9A-Za-z]
         let ret = Math.floor(Math.random() * 62) + 48;
         if (ret <= 57) return String.fromCharCode(ret);
         ret += 7;

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,7 +1,9 @@
 const MbzController = require('./mbz-controller');
 const TagController = require('./tag-controller');
+const ApiKeyController = require('./api-key-controller');
 
 module.exports = {
   MbzController,
-  TagController
+  TagController,
+  ApiKeyController
 }

--- a/controllers/tag-controller.js
+++ b/controllers/tag-controller.js
@@ -1,58 +1,12 @@
+const MakeCrudFromMongoSchema = require('../utilities/make-crud-from-mongo-schema');
 const { Tag } = require('../models');
 
-async function getTags(req, res) {
-    const result = await Tag.find({}, { name: true });
-    res.json(result.map(doc => doc.name));
-}
+const crudCreator = MakeCrudFromMongoSchema('tag', Tag, 'name');
 
-async function getTag(req, res) {
-    const result = await Tag.findOne({ name: req.params.tagname });
-    if(!result) return res.status(404).send('A tag with that name cannot be found.');
-
-    res.json(result);
-}
-
-async function postTag(req, res) {
-    try {
-        const tag = new Tag();
-        Object.assign(tag, req.body);
-        await tag.save();
-        res.send('Ok');
-    } catch(e) {
-        if (e.name === "MongoError" && e.code === 11000)
-            return res.status(409).send();
-        else if (e.name === "ValidationError")
-            return res.status(400).send(e.message.substr(e.message.indexOf(": ")+2));
-        else
-            throw e;
-    }
-}
-
-async function putTag(req, res) {
-    const tag = await Tag.findOne({ name: req.params.tagname });
-    if(!tag) return res.status(404).send('A tag with that name cannot be found.');
-
-    try {
-        Object.assign(tag, req.body);
-        await tag.save();
-        res.send('Ok');
-    } catch(e) {
-        if (e.name === "MongoError" && e.code === 11000)
-            return res.status(409).send();
-        else if (e.name === "ValidationError")
-            return res.status(400).send(e.message.substr(e.message.indexOf(": ")+2));
-        else
-            throw e;
-    }
-}
-
-async function deleteTag(req, res) {
-    const tag = await Tag.findOne({ name: req.params.tagname });
-    if(!tag) return res.status(404).send('A tag with that name cannot be found.');
-
-    await tag.delete();
-
-    res.status(204).send();
-}
-
-module.exports = { getTags, getTag, postTag, putTag, deleteTag };
+module.exports = {
+    getTags: crudCreator.makeList(),
+    getTag: crudCreator.makeRead('tagname'),
+    postTag: crudCreator.makeCreate(),
+    putTag: crudCreator.makeUpdate('tagname'),
+    deleteTag: crudCreator.makeDelete('tagname')
+};

--- a/models/api-key.js
+++ b/models/api-key.js
@@ -1,0 +1,11 @@
+require('./connect.js');
+const mongoose = require('mongoose');
+const config = require('../utilities/config');
+
+module.exports = mongoose.model(config.apiKeysCollection, new mongoose.Schema({
+    key: {
+        type: String,
+        required: true,
+        unique: true
+    }
+}));

--- a/models/index.js
+++ b/models/index.js
@@ -1,3 +1,4 @@
 const Tag = require('./tag.js');
+const ApiKey = require('./api-key.js');
 
-module.exports = { Tag };
+module.exports = { Tag, ApiKey };

--- a/router.js
+++ b/router.js
@@ -2,7 +2,7 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const asyncHandler = require('express-async-handler');
 const isValidApiKey = require('./utilities/is-valid-api-key');
-const { MbzController, TagController } = require('./controllers');
+const { MbzController, TagController, ApiKeyController } = require('./controllers');
 
 module.exports = function(app) {
   app.use(cors());
@@ -23,4 +23,7 @@ module.exports = function(app) {
   app.get('/tags/:tagname', asyncHandler(TagController.getTag));
   app.put('/tags/:tagname', bodyParser.json(), asyncHandler(TagController.putTag));
   app.delete('/tags/:tagname', asyncHandler(TagController.deleteTag));
+  app.get('/api-keys', asyncHandler(ApiKeyController.getKeys));
+  app.post('/api-keys', asyncHandler(ApiKeyController.createKey));
+  app.delete('/api-keys/:key', asyncHandler(ApiKeyController.deleteKey));
 }

--- a/utilities/is-valid-api-key.js
+++ b/utilities/is-valid-api-key.js
@@ -1,9 +1,10 @@
 const config = require('./config');
+const ApiKey = require('../models/api-key');
 
 async function isValidApiKey(key) {
     if (key === config.superuserApiKey) return true;
 
-    return false;
+    return (await ApiKey.findOne({ key: key })) !== null;
 }
 
 module.exports = isValidApiKey;

--- a/utilities/is-valid-api-key.js
+++ b/utilities/is-valid-api-key.js
@@ -1,0 +1,9 @@
+const config = require('./config');
+
+async function isValidApiKey(key) {
+    if (key === config.superuserApiKey) return true;
+
+    return false;
+}
+
+module.exports = isValidApiKey;

--- a/utilities/make-crud-from-mongo-schema.js
+++ b/utilities/make-crud-from-mongo-schema.js
@@ -1,0 +1,90 @@
+/** 
+ * Create an object containing helper functions to make crud operations out of mongoose models.
+ * First argument is the name for one object in the collection (used for error messages).
+ * Second argument is the mongoose model.
+ * Third is the property name used to uniquely identify an instance of the model.
+ * 
+ * @example See controllers/tag-controller.js
+ */
+module.exports = function (name, model, uniqueProperty) {
+  // Return an object with a bunch of anonymous functions
+  return {
+    /**
+     * Make an asynchronous express request handler to list all objects in the collection by their unique name.
+     */
+    makeList: () => async (req, res) => {
+      const projection = {};
+      projection[uniqueProperty] = true;
+      const result = await model.find({}, projection);
+      res.json(result.map(doc => doc[uniqueProperty]));
+    },
+    /**
+     * Make an asynchronous express request handler to create an object and add it to the collection.
+     * The 'C' in 'CRUD'
+     */
+    makeCreate: () => async (req, res) => {
+      try {
+        const obj = new model();
+        Object.assign(obj, req.body);
+        await obj.save();
+        res.send('Ok');
+      } catch(e) {
+        if (e.name === "MongoError" && e.code === 11000)
+          return res.status(409).send();
+        else if (e.name === "ValidationError")
+          return res.status(400).send(e.message.substr(e.message.indexOf(": ")+2));
+        else
+          throw e;
+      }
+    },
+    /**
+     * Make an asynchronous express request handler to return one object from the collection with the given route parameter name.
+     * The 'R' in 'CRUD'
+     */
+    makeRead: (routeParamName) => async (req, res) => {
+      const filter = {};
+      filter[uniqueProperty] = req.params[routeParamName];
+      const result = await model.findOne(filter);
+      if(!result) return res.status(404).send(`A ${name} with that ${uniqueProperty} cannot be found.`);
+
+      res.json(result);
+    },
+    /**
+     * Make an asynchronous express request handler to update one object from the collection with the given route parameter name.
+     * The 'U' in 'CRUD'
+     */
+    makeUpdate: (routeParamName) => async (req, res) => {
+      const filter = {};
+      filter[uniqueProperty] = req.params[routeParamName];
+      const obj = await model.findOne(filter);
+      if(!obj) return res.status(404).send(`A ${name} with that ${uniqueProperty} cannot be found.`);
+
+      try {
+          Object.assign(obj, req.body);
+          await obj.save();
+          res.send('Ok');
+      } catch(e) {
+          if (e.name === "MongoError" && e.code === 11000)
+              return res.status(409).send();
+          else if (e.name === "ValidationError")
+              return res.status(400).send(e.message.substr(e.message.indexOf(": ")+2));
+          else
+              throw e;
+      }
+    },
+    /**
+     * Make an asynchronous express request handler to delete an object from the collection with the given route parameter name.
+     * The 'D' in 'CRUD'
+     */
+    makeDelete: (routeParamName) => async (req, res) => {
+      const filter = {};
+      filter[uniqueProperty] = req.params[routeParamName];
+      const obj = await model.findOne(filter);
+      if(!obj) return res.status(404).send(`A ${name} with that ${uniqueProperty} cannot be found.`);
+
+      await obj.delete();
+
+      res.status(204).send();
+    }
+  };
+};


### PR DESCRIPTION
**All** routes protected with API keys: must use Authorization header.
The provided key must be either in the mongodb database, or specified as the superuserApiKey in the config file.

New endpoints:
`GET /api-keys`: Returns an array of api keys
`POST /api-keys`: Generates a new random api key (ignored POST body)
`DELETE /api-key/:key`: Deletes the specified api key. Note: you cannot delete the key you're currently using (to prevent you from accidentally blocking yourself out).

Note: To avoid WET code, most of the code from TagController was moved to makeCrudFromMongoSchema to be reused by ApiKeyController.